### PR TITLE
Sensei Input and Params schema for Adobe XD 

### DIFF
--- a/custom-json/simple-object.json
+++ b/custom-json/simple-object.json
@@ -1,0 +1,14 @@
+{
+        "$schema": "http://json-schema.org/draft-07/schema",
+        "$id": "http://example.com/example.json",
+        "type": "object",
+        "title": "Object",
+        "description": "A simple object schema",
+        "default": {},
+        "examples": [
+          {}
+        ],
+        "required": [],
+        "additionalProperties": true,
+        "properties": {}
+      }

--- a/custom-json/xd-asset-extraction-config.json
+++ b/custom-json/xd-asset-extraction-config.json
@@ -1,0 +1,97 @@
+{
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "type": "object",
+        "properties": {
+          "rendition": {
+            "anyOf": [
+              {
+                "type": "object",
+                "properties": {
+                  "rendition_mimetype": {
+                    "type": "string",
+                    "enum": ["image/png", "image/jpg", "image/webp", "application/pdf", "image/svg"]
+                  },
+                  "rendition_scale": {
+                    "type": "number",
+                    "minimum": 0.25,
+                    "maximum": 3.0
+                  },
+                  "rendition_size": {
+                    "type": "number"
+                  },
+                  "rendition_quality": {
+                    "type": "integer",
+                    "minimum": 50,
+                    "maximum": 100
+                  },
+                  "resource_fragment": {
+                    "type": "object",
+                    "properties": {
+                      "artboardID": {
+                        "type": "string"
+                      },
+                      "layerID": {
+                        "type": "string"
+                      }
+                    },
+                    "additionalProperties": false,
+                    "required": [
+                      "artboardID"
+                    ]
+                  }
+                },
+                "additionalProperties": false,
+                "required": [
+                  "resource_fragment"
+                ]
+              },
+              {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "rendition_mimetype": {
+                      "type": "string",
+                      "enum": ["image/png", "image/jpg", "image/webp", "application/pdf", "image/svg"]
+                    },
+                    "rendition_scale": {
+                      "type": "number",
+                      "minimum": 0.25,
+                      "maximum": 3.0
+                    },
+                    "rendition_size": {
+                      "type": "number"
+                    },
+                    "rendition_quality": {
+                      "type": "integer",
+                      "minimum": 50,
+                      "maximum": 100
+                    },
+                    "resource_fragment": {
+                      "type": "object",
+                      "properties": {
+                        "artboardID": {
+                          "type": "string"
+                        },
+                        "layerID": {
+                          "type": "string"
+                        }
+                      },
+                      "additionalProperties": false,
+                      "required": [
+                        "artboardID"
+                      ]
+                    }
+                  },
+                  "additionalProperties": false,
+                  "required": [
+                    "resource_fragment"
+                  ]
+                }
+              }
+            ]
+          }
+        },
+        "additionalProperties": false,
+        "required": []
+      }


### PR DESCRIPTION
Sensei Input and Params schema for Adobe XD. 

- Input schema to allow content reference (ID/path of dcx), Repository details and any download/parsing filter. 
- Extraction config is optional, can contain single on-demand extraction or batch extraction.